### PR TITLE
Java 10 compatibilty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.5</version>
+        <version>2.22.0</version>
         <configuration>
           <useManifestOnlyJar>false</useManifestOnlyJar>
         </configuration>
@@ -55,10 +55,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.7.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <fork>true</fork>
         </configuration>
       </plugin>
       <plugin>
@@ -123,12 +124,12 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.16.10</version>
+      <version>1.16.22</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jackrabbit</groupId>
       <artifactId>jackrabbit-core</artifactId>
-      <version>2.10.4</version>
+      <version>2.16.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -196,6 +197,23 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>java-10</id>
+      <activation>
+        <jdk>10</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+                <useManifestOnlyJar>false</useManifestOnlyJar>
+                <argLine>--add-modules java.sql</argLine>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Since Magnolia 5.7 supports Java 9 and Java 10, it would be nice if 'jcr-criteria' would support Java 10 as well.
It seems as if updating Lombok is all which is necessary to make 'jcr-critera' work with Java 10.

Changes:
- Update Lombok to 16.10.22 (Java 10 support)
- Update Maven plugins and add profile, to allow compilation with Java 10