### PR TITLE
Restrict not condition to wrapped condition

### DIFF
--- a/src/main/java/nl/vpro/jcr/criteria/query/sql2/NotCondition.java
+++ b/src/main/java/nl/vpro/jcr/criteria/query/sql2/NotCondition.java
@@ -14,9 +14,9 @@ public class NotCondition implements Condition {
 
     @Override
     public boolean toSql2(StringBuilder builder) {
-        builder.append("not (");
+        builder.append("(not (");
         wrapped.toSql2(builder);
-        builder.append(")");
+        builder.append("))");
         return true;
     }
 }


### PR DESCRIPTION
 - Without brackets it affects following conditions
 e.g.:
```
SELECT * from [nt:base] as a 
WHERE (
[jcr:primaryType] = 'mgnl:page' 
AND (not ([test] = '42')) 
AND (not ([test2] = '42'))
)
```