### PR TITLE
Fix NullPointer on paged query with date restrictions on getTotalSize()

### DIFF
--- a/src/main/java/nl/vpro/jcr/criteria/query/impl/AbstractCriteriaImpl.java
+++ b/src/main/java/nl/vpro/jcr/criteria/query/impl/AbstractCriteriaImpl.java
@@ -205,6 +205,7 @@ public abstract class AbstractCriteriaImpl implements TranslatableCriteria {
                 }
                 countCriteria.setBasePath(basePath);
                 countCriteria.setType(type);
+                countCriteria.setTimeZone(timeZone);
                 countCriteria.setSpellCheckString(spellCheckString);
 
                 expr = countCriteria.toExpression(language);


### PR DESCRIPTION
AdvancedResult.getTotalSize() fails on for paged queries with date restrictions, beacuse the time zone is not set in the getCountSupplier query:

```
JCRCriteriaFactory.builder()
				.basePath("/")
				.timeZone(zoneId)
				.add(Restrictions.gt("someDate", LocalDateTime.now())) 
				.offset(pageNumber * pageSize)
				.maxResults(pageSize)
				.build();
```

```
java.lang.NullPointerException: zone
	at java.util.Objects.requireNonNull(Objects.java:246) ~[?:?]
	at java.time.ZonedDateTime.ofLocal(ZonedDateTime.java:368) ~[?:?]
	at java.time.ZonedDateTime.of(ZonedDateTime.java:293) ~[?:?]
	at java.time.LocalDateTime.atZone(LocalDateTime.java:1800) ~[?:?]
	at nl.vpro.jcr.utils.Utils.toCalendarIfPossible(Utils.java:18) ~[jcr-criteria-2.10.jar:?]
	at nl.vpro.jcr.criteria.query.sql2.SimpleExpressionCondition.of(SimpleExpressionCondition.java:45) ~[jcr-criteria-2.10.jar:?]
	at nl.vpro.jcr.criteria.query.criterion.SimpleExpression.toSQLCondition(SimpleExpression.java:117) ~[jcr-criteria-2.10.jar:?]
	at nl.vpro.jcr.criteria.query.sql2.Select.from(Select.java:68) ~[jcr-criteria-2.10.jar:?]
	at nl.vpro.jcr.criteria.query.impl.AbstractCriteriaImpl.toSql2Expression(AbstractCriteriaImpl.java:174) ~[jcr-criteria-2.10.jar:?]
	at nl.vpro.jcr.criteria.query.Criteria.toExpression(Criteria.java:199) ~[jcr-criteria-2.10.jar:?]
	at nl.vpro.jcr.criteria.query.impl.AbstractCriteriaImpl.lambda$getCountSupplier$1(AbstractCriteriaImpl.java:210) ~[jcr-criteria-2.10.jar:?]
	at nl.vpro.jcr.criteria.advanced.impl.AdvancedResultImpl.getTotalSize(AdvancedResultImpl.java:120) ~[jcr-criteria-2.10.jar:?]
```

Is it possible to create a new release after merging this PR if it is fine for you?